### PR TITLE
Fix an incorrect description about total_kapredi_r009bit11.bin

### DIFF
--- a/Tutorials_as_Jupyter_Notebooks/ECCO_v4_Loading_LLC_compact_binary_files.ipynb
+++ b/Tutorials_as_Jupyter_Notebooks/ECCO_v4_Loading_LLC_compact_binary_files.ipynb
@@ -627,7 +627,8 @@
     "## Example 3: Load a 3D 'compact' llc binary file with 3rd dimension = Depth\n",
     "\n",
     "\n",
-    "The file 'total_kapredi_r009bit11.bin' is a 50 depth level array of the adjusted GM redi parameter (first guess + adjustments), dimensions of [depth, j, i]"
+    "The file 'total_kapredi_r009bit11.bin' is a 50 depth level array of the adjusted Redi parameter from Release 1 (first guess + adjustments), dimensions of [depth, j, i]\n",
+    "Release 4's adjusted Redi parameter can be found at https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/ECCO_L4_OCEAN_3D_MIX_COEFFS_LLC0090GRID_V4R4/OCEAN_3D_MIXING_COEFFS_ECCO_V4r4_native_llc0090.nc"
    ]
   },
   {
@@ -985,7 +986,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/Tutorials_as_Python_Files/ECCO_v4_Loading_LLC_compact_binary_files.py
+++ b/Tutorials_as_Python_Files/ECCO_v4_Loading_LLC_compact_binary_files.py
@@ -247,8 +247,9 @@ print(runoff_DA2.coords)
 # ## Example 3: Load a 3D 'compact' llc binary file with 3rd dimension = Depth
 # 
 # 
-# The file 'total_kapredi_r009bit11.bin' is a 50 depth level array of the adjusted GM redi parameter (first guess + adjustments), dimensions of [depth, j, i]
-
+# The file 'total_kapredi_r009bit11.bin' is a 50 depth level array of the adjusted Redi parameter from Release 1 (first guess + adjustments), dimensions of [depth, j, i]
+# Release 4's adjusted Redi parameter can be found at https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/ECCO_L4_OCEAN_3D_MIX_COEFFS_LLC0090GRID_V4R4/OCEAN_3D_MIXING_COEFFS_ECCO_V4r4_native_llc0090.nc
+#
 # In[22]:
 
 


### PR DESCRIPTION
Fix an incorrect description about total_kapredi_r009bit11.bin
total_kapredi_r009bit11.bin is the adjusted Redi parameter from ECCO Version 4 **Release 1**, not from Release 4. 