### PR TITLE
fixed reference to interpolation to lat-lon tutorial

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,7 +47,7 @@ The `ecco_v4_py`_ package used in this tutorial was inspired by the `xmitgcm`_ p
    ECCO_v4_Loading_LLC_compact_binary_files.ipynb
    ECCO_v4_Combining_Multiple_Datasets.ipynb
    ECCO_v4_Saving_Datasets_and_DataArrays_to_NetCDF.ipynb
-   ECCO_v4_Interpolating_to_latlon.ipynb
+   ECCO_v4_Interpolating_Fields_to_LatLon_Grid.ipynb
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
now with vector rotation (actually from January but for some reason not updated in the index.rst)