### PR TITLE
Add missing version argument at lines 342 and 441 in ecco_download.py

### DIFF
--- a/ecco_access/ecco_download.py
+++ b/ecco_access/ecco_download.py
@@ -339,7 +339,7 @@ def download_files_wrapper(urls, download_dir, version, n_workers, force_redownl
         for u in urls:
             u_name = u.split('/')[-1]
             print(f'downloading {u_name}')
-            result = download_file(url=u, output_dir=download_dir, force=force_redownload, show_noredownload_msg=show_noredownload_msg)
+            result = download_file(url=u, output_dir=download_dir, version=version, force=force_redownload, show_noredownload_msg=show_noredownload_msg)
             downloaded_files.append(result[0])
             total_download_size_in_bytes += result[-1]
         
@@ -438,7 +438,7 @@ def ecco_podaac_download(ShortName,StartDate,EndDate,version,snapshot_interval='
     
     # Download the granules
     
-    downloaded_files = download_files_wrapper(urls, download_dir, n_workers, force_redownload, show_noredownload_msg)
+    downloaded_files = download_files_wrapper(urls, download_dir, version, n_workers, force_redownload, show_noredownload_msg)
     
     if return_downloaded_files:
         if len(downloaded_files) == 1:


### PR DESCRIPTION
Many thanks to the ECCO team for their hard work on this valuable package.
 
<br>

In ecco_access/ecco_download.py, the "version" argument was missing in two spots:

- In defining ecco_podaac_download(), the call of download_files_wrapper() (at line 441) did not include the version parameter.

- Similarly, in defining download_files_wrapper(), a call of download_file() (at line 342) was also missing the version parameter.

<br>

Note that this is the same issue as raised by @cspencerjones in Issue #105.  

This pull request adds the missing version argument at both of these instances. This fixes the error below while trying to follow the [Direct download over the internet (mode = ‘download’)](https://ecco-v4-python-tutorial.readthedocs.io/ECCO_access_intro.html#Direct-download-over-the-internet-(mode-=-'download')) section of the ECCOv4 Python tutorial:

<br>

```
SSH_monthly_shortname = 'ECCO_L4_SSH_LLC0090GRID_MONTHLY_V4R4'
ds_SSH = ea.ecco_podaac_to_xrdataset(SSH_monthly_shortname,\
                                        StartDate='2017-01',EndDate='2017-12',\
                                        mode='download',\
                                        download_root_dir=join(user_home_dir,'Downloads','ECCO_V4r4_PODAAC'))
```

which gives the error:

```
File ~/ECCO-v4-Python-Tutorial/ecco_access/ecco_download.py:441, in ecco_podaac_download(ShortName, StartDate, EndDate, version, snapshot_interval, download_root_dir, n_workers, force_redownload, show_noredownload_msg, return_downloaded_files)
    437 urls,sizes = ecco_podaac_query(ShortName,StartDate,EndDate,version,snapshot_interval)
    439 # Download the granules
--> 441 downloaded_files = download_files_wrapper(urls, download_dir, n_workers, force_redownload, show_noredownload_msg)
    443 if return_downloaded_files:
    444     if len(downloaded_files) == 1:
    445         # if only 1 file is downloaded, return a string of filename instead of a list

TypeError: download_files_wrapper() missing 1 required positional argument: 'show_noredownload_msg'
```